### PR TITLE
Mark and clear full rows.

### DIFF
--- a/src/board.cc
+++ b/src/board.cc
@@ -3,28 +3,6 @@
 #include "board.h"
 #include "game.h"
 
-bool noEmptySpacesInRange(const char *grid, int start, int end) {
-  for (int j = start; j < end; ++j) {
-    if (grid[j] == ' ') {
-      return false;
-    }
-  }
-  return true;
-}
-
-void getFullRowsRange(const char *board, int &start, int &end) {
-  int _start = -1;
-  int _end = -1;
-  for (int i = 0; i < H_BOARD; ++i) {
-    if (noEmptySpacesInRange(board, i * W_BOARD, i * W_BOARD + W_BOARD)) {
-      if (_start == -1) _start = i * W_BOARD;
-      _end = i * W_BOARD + W_BOARD;
-    }
-  }
-  start = _start;
-  end = _end;
-}
-
 bool inBounds(Shape board, Shape shape, point_t dst) {
   if (dst.row - shape.getBBox().uLeft.row < 0) return false;
   if (dst.row > board.getRows() - shape.getBBox().lRight.row) return false;

--- a/src/board.h
+++ b/src/board.h
@@ -3,23 +3,6 @@
 #include "piece.h"
 
 /**
- * Return true if the range of characters from start to end (exclusive)
- * contains no empty spaces.
- */
-bool noEmptySpacesInRange(const char *board, int start, int end);
-
-/**
- * Set start and end to the beginning and end character positions in board
- * of the rows that have no empty spaces in them.
- *
- * If there are no non-empty rows, start and end are set to -1.
- *
- * This assumes that all non-empty rows are contiguous, which is guaranteed
- * with the normal set of seven Tetris pieces.
- */
-void getFullRowsRange(const char *board, int &start, int &end);
-
-/**
  * Returns true if the given piece can be placed on the board at the given
  * point.
  *
@@ -29,12 +12,4 @@ void getFullRowsRange(const char *board, int &start, int &end);
  * The destination point is in board space. It may have negative coordinates.
  */
 bool inBounds(Shape board, Shape shape, point_t dst);
-
-/**
- * Return true if any of the tiles in shape collide with tiles on the board
- * when shape is moved to the given point.
- *
- * The destination point is in board space.
- */
-bool collide(Shape board, Shape shape, point_t dst);
 

--- a/src/game.h
+++ b/src/game.h
@@ -12,8 +12,9 @@ const int H_PIECE = 4;
 const int START_ROW = 2;
 const int START_COL = 4;
 
-const char EMPTY_SPACE = ' ';
 const point_t START_COORDINATES = (struct point) { 0, 3 };
+const point_t OFFSCREEN_COORDINATES = (struct point) { -4, 3 };
+
 const bbox_t BOARD_AREA = (struct bbox) {
   (struct point) { 0, 0 },
   (struct point) { H_BOARD - 1, W_BOARD - 1}
@@ -23,12 +24,19 @@ typedef struct stats {
   int score;
 } stats_t;
 
+typedef enum state {
+  PLAYING,
+  SHOWING_FULL_ROWS,
+  DELETING_FULL_ROWS,
+} state_t;
+
 class Game {
 
   public:
     Game(const Shape &canvas,
          const Sequence &sequence,
          void (*gameOverCallback)(void));
+    bool setGrid(const char *grid);
     bool moveLeft();
     bool moveRight();
     bool rotateClockwise();
@@ -45,9 +53,13 @@ class Game {
     Shape board;
     Piece pieces[NUM_PIECES];
     stats_t stats;
+    state_t state;
     bool move(orientation_t dir);
+    void stickCurrentPiece();
+    void hideCurrentPiece();
     void produceNextPiece();
-    void score(int);
+    void scoreRemovedRows(int rows);
+    void scoreDroppedRows(int rows);
     void render();
     void gameOver();
     void (*gameOverCallback)(void);

--- a/src/piece.h
+++ b/src/piece.h
@@ -3,6 +3,9 @@
 #include <stdint.h>
 #include <shape.h>
 
+const char EMPTY_SPACE = ' ';
+const char DEAD_CELL = 'X';
+
 typedef enum {
   UP,
   RIGHT,

--- a/src/sequence.cc
+++ b/src/sequence.cc
@@ -18,7 +18,7 @@ long Random::choice(long from, long to) {
 #ifdef ARDUINO
   return random(from, to);
 #else
-  return from;
+  return from + (seed % to);
 #endif
 }
 
@@ -39,7 +39,6 @@ piece_name_t Sequence::next() {
 void Sequence::reshuffle() {
   reset();
 
-  // No-op; Swaps them back to their original order.
   for (uint8_t i = 0; i < NUM_PIECES; ++i) {
     uint8_t k = random.choice(i, NUM_PIECES);
     swap(seq, k, NUM_PIECES - k);

--- a/src/shape.cc
+++ b/src/shape.cc
@@ -37,6 +37,51 @@ void Shape::fillWith(char fillChar) {
   updateBoundingBox();
 }
 
+void Shape::fillRowWith(char fillChar, int row) {
+  for (int i = row * cols; i < row * cols + cols; ++i) {
+    grid[i] = fillChar;
+  }
+}
+
+bool Shape::findAndMarkRowsForRemoval() {
+  int found = false;
+  for (int row = 0; row < rows; ++row) {
+    if (noEmptySpacesInRow(row)) {
+      fillRowWith(DEAD_CELL, row);
+      found = true;
+    }
+  }
+  return found;
+}
+
+int Shape::removeRowsMarkedForRemoval() {
+  int removed = 0;
+  // If the first cell in the row is an X, the row can be removed.
+  for (int row = 0; row < rows; ++row) {
+    if (grid[row * cols] == DEAD_CELL) {
+      ++removed;
+      // Take all rows 0 .. row-1 and move them down one.
+      for (int i = row * cols + cols -1; i >= cols; --i) {
+        grid[i] = grid[i - cols];
+      }
+      // Fill in a blank first row.
+      for (int i = 0; i < cols; ++i) {
+        grid[i] = EMPTY_SPACE;
+      }
+    }
+  }
+  return removed;
+}
+
+bool Shape::noEmptySpacesInRow(int row) {
+  for (int i = cols * row; i < cols * row + cols; ++i) {
+    if (grid[i] == ' ') {
+      return false;
+    }
+  }
+  return true;
+}
+
 bool Shape::within(bbox_t other, point_t dst) {
   if (bbox.uLeft.row + dst.row < other.uLeft.row) return false;
   if (bbox.uLeft.col + dst.col < other.uLeft.col) return false;

--- a/src/shape.h
+++ b/src/shape.h
@@ -32,6 +32,10 @@ class Shape {
     void setCharAt(char c, point_t coordinates);
     void fillWithChars(const char *chars);
     void fillWith(char fillChar);
+    void fillRowWith(char fillChar, int row);
+    bool findAndMarkRowsForRemoval();
+    int removeRowsMarkedForRemoval();
+    bool noEmptySpacesInRow(int row);
     bool within(bbox_t bbox, point_t dst);
     bool collides(const Shape &other, point_t dst);
     void stick(const Shape &other, point_t dst);

--- a/test/test_desktop/test_desktop.cc
+++ b/test/test_desktop/test_desktop.cc
@@ -5,25 +5,8 @@
 #include <sequence.h>
 #include <unity.h>
 #include "test_desktop_data.h"
-#include <iostream>
 
 void noOpCallback() {
-}
-
-void test_empty_rows(void) {
-  int start = -2;
-  int end = -2;
-  getFullRowsRange(board0_grid, start, end);
-  TEST_ASSERT_EQUAL(-1, start);
-  TEST_ASSERT_EQUAL(-1, end);
-}
-
-void test_non_empty_rows(void) {
-  int start = -2;
-  int end = -2;
-  getFullRowsRange(board1_grid, start, end);
-  TEST_ASSERT_EQUAL(160, start);
-  TEST_ASSERT_EQUAL(200, end);
 }
 
 void test_row_empty(void) {
@@ -554,12 +537,110 @@ void test_reset(void) {
   TEST_ASSERT_EQUAL(0, game.getStats().score);
 }
 
+void test_clear_one_row_after_dropping(void) {
+  Shape canvas = Shape(20, 10, board_empty_grid);
+  Sequence sequence = Sequence(0);
+  Game game = Game(canvas, sequence, noOpCallback);
+
+  // Drop the I in the middle.
+  game.drop();
+
+  // Drop the J on the left.
+  game.moveLeft();
+  game.moveLeft();
+  game.moveLeft();
+  game.drop();
+
+  // Drop the L on the right.
+  game.moveRight();
+  game.moveRight();
+  game.moveRight();
+  game.moveRight();
+  game.drop();
+
+  // The bottom row is full and is marked for deletion.
+  TEST_ASSERT_TRUE(canvas.noEmptySpacesInRow(19));
+  TEST_ASSERT_TRUE(canvas == Shape(20, 10, board_with_full_row_marked_for_deletion));
+
+  // Ticking forward in time removes the row.
+  game.tick();
+  // Another tick exposes the next piece.
+  game.tick();
+  TEST_ASSERT_TRUE(canvas == Shape(20, 10, board_with_full_row_deleted_and_next_piece_showing));
+}
+
+void test_clear_one_row_after_ticking_down() {
+  Shape canvas = Shape(20, 10, board_empty_grid);
+  Sequence sequence = Sequence(0);
+  Game game = Game(canvas, sequence, noOpCallback);
+
+  // Drop the I in the middle.
+  game.drop();
+
+  // Drop the J on the left.
+  game.moveLeft();
+  game.moveLeft();
+  game.moveLeft();
+  game.drop();
+
+  // Move the L to the right and let it eventually tick down.
+  game.moveRight();
+  game.moveRight();
+  game.moveRight();
+  game.moveRight();
+  game.tick();
+  game.tick();
+  game.tick();
+  game.tick();
+  game.tick();
+  game.tick();
+  game.tick();
+  game.tick();
+  game.tick();
+  game.tick();
+  game.tick();
+  game.tick();
+  game.tick();
+  game.tick();
+  game.tick();
+  game.tick();
+  game.tick();
+  game.tick();
+  game.tick();
+
+  // The bottom row is full and is marked for deletion.
+  TEST_ASSERT_TRUE(canvas.noEmptySpacesInRow(19));
+  TEST_ASSERT_TRUE(canvas == Shape(20, 10, board_with_full_row_marked_for_deletion));
+
+  // Ticking forward in time removes the row.
+  game.tick();
+  // Another tick exposes the next piece.
+  game.tick();
+  TEST_ASSERT_TRUE(canvas == Shape(20, 10, board_with_full_row_deleted_and_next_piece_showing));
+}
+
+void test_scoring(void) {
+  Shape canvas = Shape(20, 10, board_empty_grid);
+  Sequence sequence = Sequence(0);
+  Game game = Game(canvas, sequence, noOpCallback);
+
+  game.setGrid(board0_grid);
+  game.rotateClockwise();
+
+  game.moveRight();
+  game.moveRight();
+  game.moveRight();
+  game.moveRight();
+  game.drop();
+
+  game.tick();
+  game.tick();
+  // Score 16 rows dropped, and 1200 for a "tetris".
+  TEST_ASSERT_EQUAL(1216, game.getStats().score);
+}
+
 int main(int argc, char** argv) {
   UNITY_BEGIN();
-
-  // board.h
-  RUN_TEST(test_empty_rows);
-  RUN_TEST(test_non_empty_rows);
 
   // piece.h
   RUN_TEST(test_rotate_clockwise);
@@ -596,6 +677,9 @@ int main(int argc, char** argv) {
   RUN_TEST(test_drop);
   RUN_TEST(test_game_over);
   RUN_TEST(test_drop_points);
+  RUN_TEST(test_clear_one_row_after_dropping);
+  RUN_TEST(test_clear_one_row_after_ticking_down);
+  RUN_TEST(test_scoring);
 
   UNITY_END();
 }

--- a/test/test_desktop/test_desktop_data.h
+++ b/test/test_desktop/test_desktop_data.h
@@ -285,6 +285,51 @@ const char *board_with_first_piece_far_right =
   "          "
   "          ";
 
+const char *board_with_full_row_marked_for_deletion =
+  "          "
+  "          "
+  "          "
+  "          "
+  "          "
+  "          "
+  "          "
+  "          "
+  "          "
+  "          "
+  "          "
+  "          "
+  "          "
+  "          "
+  "          "
+  "          "
+  "          "
+  "          "
+  "J        L"
+  "XXXXXXXXXX";
+
+const char *board_with_full_row_deleted_and_next_piece_showing =
+  "          "
+  "    OO    "
+  "    OO    "
+  "          "
+  "          "
+  "          "
+  "          "
+  "          "
+  "          "
+  "          "
+  "          "
+  "          "
+  "          "
+  "          "
+  "          "
+  "          "
+  "          "
+  "          "
+  "          "
+  "J        L";
+
+
 const char *board0_grid =
   "          "
   "          "


### PR DESCRIPTION
    After dropping or time advancing (tick()), we check for full rows.

    Full rows are all converted to the 'X' character and rendered for a
    tick. The display manager can do something interesting with this.

    On the subsequent tick, the rows are removed from the board, everything
    slides down accordingly, and the score is updated.